### PR TITLE
[client][trace] Use net/http/httptrace for generic write client Fix #10

### DIFF
--- a/libtsdb/client.go
+++ b/libtsdb/client.go
@@ -14,6 +14,16 @@ type WriteClient interface {
 	Flush() error
 }
 
+type TracedHttpClient interface {
+	EnableHttpTrace()
+	DisableHttpTrace()
+	Trace() HttpTrace
+}
+
+//type HttpResponse interface {
+//	StatusCode() int
+//}
+
 type HttpClient interface {
 	SetHttpClient(client *http.Client)
 }

--- a/libtsdb/client.go
+++ b/libtsdb/client.go
@@ -20,12 +20,9 @@ type TracedHttpClient interface {
 	Trace() HttpTrace
 }
 
-//type HttpResponse interface {
-//	StatusCode() int
-//}
-
 type HttpClient interface {
 	SetHttpClient(client *http.Client)
+	HttpStatusCode() int
 }
 
 type HttpWriteClient interface {

--- a/libtsdb/client/genericw/client.go
+++ b/libtsdb/client/genericw/client.go
@@ -107,37 +107,37 @@ func (c *Client) send() error {
 
 	// trace based on https://github.com/rakyll/hey/blob/master/requester/requester.go#L141
 	trace := &c.trace
-	trace.Start = time.Now()
+	trace.Start = time.Now().UnixNano()
 	if c.enableTrace {
 		tracer := &httptrace.ClientTrace{
 			DNSStart: func(info httptrace.DNSStartInfo) {
-				trace.DNSStart = time.Now()
+				trace.DNSStart = time.Now().UnixNano()
 			},
 			DNSDone: func(info httptrace.DNSDoneInfo) {
-				trace.DNSDone = time.Now()
+				trace.DNSDone = time.Now().UnixNano()
 			},
 			// TODO: can we just ignore ConnectStart and ConnectDone?
 			GetConn: func(hostPort string) {
-				trace.GetConn = time.Now()
+				trace.GetConn = time.Now().UnixNano()
 			},
 			GotConn: func(info httptrace.GotConnInfo) {
-				now := time.Now()
+				now := time.Now().UnixNano()
 				trace.Reused = info.Reused
 				trace.GotConn = now
 				trace.ReqStart = now
 			},
 			// TODO: only tls handshake when new connection is established?
 			TLSHandshakeStart: func() {
-				trace.TLSStart = time.Now()
+				trace.TLSStart = time.Now().UnixNano()
 			},
 			TLSHandshakeDone: func(state tls.ConnectionState, e error) {
-				trace.TLSStop = time.Now()
+				trace.TLSStop = time.Now().UnixNano()
 			},
 			WroteRequest: func(info httptrace.WroteRequestInfo) {
-				trace.ReqDone = time.Now()
+				trace.ReqDone = time.Now().UnixNano()
 			},
 			GotFirstResponseByte: func() {
-				trace.ResStart = time.Now()
+				trace.ResStart = time.Now().UnixNano()
 			},
 		}
 		req = req.WithContext(httptrace.WithClientTrace(req.Context(), tracer))
@@ -153,7 +153,7 @@ func (c *Client) send() error {
 		return errors.Wrap(err, "can't read response body")
 	}
 	trace.StatusCode = res.StatusCode
-	trace.ResDone = time.Now()
+	trace.ResDone = time.Now().UnixNano()
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
 		// FIXED: log due to https://github.com/xephonhq/xephon-b/issues/36
 		//log.Debugf("%d %s", res.StatusCode, string(b))

--- a/libtsdb/client/genericw/client.go
+++ b/libtsdb/client/genericw/client.go
@@ -35,9 +35,8 @@ type Client struct {
 
 	// single request
 	// TODO: compressed
-	statusCode int
-	proto      string
-	trace      libtsdb.HttpTrace
+	proto string
+	trace libtsdb.HttpTrace
 
 	// accumulated counters
 	bytesSend          uint64
@@ -93,56 +92,52 @@ func (c *Client) Trace() libtsdb.HttpTrace {
 }
 
 func (c *Client) HttpStatusCode() int {
-	return c.statusCode
+	return c.trace.StatusCode
 }
 
 func (c *Client) send() error {
+	// TODO: real bytes send also include header etc, which we didn't take into account of bytes send
 	payloadSize := uint64(c.enc.Len())
 	c.bytesSend += payloadSize
 
-	// TODO: go support http client tracing, we can also use open tracing here ...
-	// TODO: real bytes send also include header etc, which we didn't take into account of bytes send
 	req := &http.Request{}
 	*req = *c.baseReq
 	b := c.enc.Bytes()
 	req.Body = bytesutil.ReadCloser(b)
-	// based on https://github.com/rakyll/hey/blob/master/requester/requester.go#L141
-	var dnsStart, connStart, tlsStart, reqStart, resStart time.Time
+
+	// trace based on https://github.com/rakyll/hey/blob/master/requester/requester.go#L141
 	trace := &c.trace
+	trace.Start = time.Now()
 	if c.enableTrace {
 		tracer := &httptrace.ClientTrace{
 			DNSStart: func(info httptrace.DNSStartInfo) {
-				dnsStart = time.Now()
+				trace.DNSStart = time.Now()
 			},
 			DNSDone: func(info httptrace.DNSDoneInfo) {
-				trace.DnsDuration = time.Now().Sub(dnsStart)
+				trace.DNSDone = time.Now()
 			},
 			// TODO: can we just ignore ConnectStart and ConnectDone?
 			GetConn: func(hostPort string) {
-				connStart = time.Now()
+				trace.GetConn = time.Now()
 			},
 			GotConn: func(info httptrace.GotConnInfo) {
-				// TODO: info also contains Idle etc.
 				now := time.Now()
-				if info.Reused {
-					trace.ConnDuration = 0
-				} else {
-					trace.ConnDuration = now.Sub(connStart)
-				}
-				reqStart = now
+				trace.Reused = info.Reused
+				trace.GotConn = now
+				trace.ReqStart = now
 			},
 			// TODO: only tls handshake when new connection is established?
 			TLSHandshakeStart: func() {
-				tlsStart = time.Now()
+				trace.TLSStart = time.Now()
 			},
 			TLSHandshakeDone: func(state tls.ConnectionState, e error) {
-				trace.TlsDuration = time.Now().Sub(tlsStart)
+				trace.TLSStop = time.Now()
 			},
 			WroteRequest: func(info httptrace.WroteRequestInfo) {
-				trace.ReqDuration = time.Now().Sub(reqStart)
+				trace.ReqDone = time.Now()
 			},
 			GotFirstResponseByte: func() {
-				resStart = time.Now()
+				trace.ResStart = time.Now()
 			},
 		}
 		req = req.WithContext(httptrace.WithClientTrace(req.Context(), tracer))
@@ -157,11 +152,10 @@ func (c *Client) send() error {
 	if err != nil {
 		return errors.Wrap(err, "can't read response body")
 	}
-	c.statusCode = res.StatusCode
-	trace.ResDuration = time.Now().Sub(resStart)
+	trace.StatusCode = res.StatusCode
+	trace.ResDone = time.Now()
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
-		// TODO: might disable this since https://github.com/xephonhq/xephon-b/issues/36 is solved
-		// when the server is overwhelmed, it's pretty likely to have tons of errors ...
+		// FIXED: log due to https://github.com/xephonhq/xephon-b/issues/36
 		//log.Debugf("%d %s", res.StatusCode, string(b))
 		return errors.New(string(body))
 	}

--- a/libtsdb/client/genericw/client.go
+++ b/libtsdb/client/genericw/client.go
@@ -7,13 +7,17 @@ import (
 	"github.com/dyweb/gommon/errors"
 	"github.com/dyweb/gommon/requests"
 
+	"crypto/tls"
 	"github.com/libtsdb/libtsdb-go/libtsdb"
 	"github.com/libtsdb/libtsdb-go/libtsdb/common"
 	pb "github.com/libtsdb/libtsdb-go/libtsdb/libtsdbpb"
 	"github.com/libtsdb/libtsdb-go/libtsdb/util/bytesutil"
+	"net/http/httptrace"
+	"time"
 )
 
 var _ libtsdb.WriteClient = (*Client)(nil)
+var _ libtsdb.TracedHttpClient = (*Client)(nil)
 var _ libtsdb.HttpClient = (*Client)(nil)
 
 // Client is a generic HTTP based client for write, it is not go routine safe because encoder
@@ -24,8 +28,15 @@ type Client struct {
 	baseReq *http.Request
 	meta    libtsdb.Meta
 
-	// stat collected by client after it started running
-	proto              string
+	// flag for using http trace
+	enableTrace bool
+
+	// stat collected by client
+	// single request
+	// TODO: compressed
+	statusCode int
+	proto      string
+	// accumulated counters
 	bytesSend          uint64
 	bytesSendSuccess   uint64
 	intPointWritten    uint64
@@ -39,6 +50,14 @@ func New(meta libtsdb.Meta, encoder common.Encoder, req *http.Request) *Client {
 		baseReq: req,
 		meta:    meta,
 	}
+}
+
+func (c *Client) EnableHttpTrace() {
+	c.enableTrace = true
+}
+
+func (c *Client) DisableHttpTrace() {
+	c.enableTrace = false
 }
 
 func (c *Client) Meta() libtsdb.Meta {
@@ -66,6 +85,11 @@ func (c *Client) Flush() error {
 	return c.send()
 }
 
+func (c *Client) Trace() libtsdb.HttpTrace {
+	// FIXME: return real trace
+	return libtsdb.HttpTrace{}
+}
+
 func (c *Client) send() error {
 	payloadSize := uint64(c.enc.Len())
 	c.bytesSend += payloadSize
@@ -76,7 +100,49 @@ func (c *Client) send() error {
 	*req = *c.baseReq
 	b := c.enc.Bytes()
 	req.Body = bytesutil.ReadCloser(b)
+	// based on https://github.com/rakyll/hey/blob/master/requester/requester.go#L141
+	var dnsStart, connStart, tlsStart, reqStart, resStart time.Time
+	var dnsDuration, connDuration, tlsDuration, reqDuration, resDuration time.Duration
+	if c.enableTrace {
+		trace := &httptrace.ClientTrace{
+			DNSStart: func(info httptrace.DNSStartInfo) {
+				dnsStart = time.Now()
+			},
+			DNSDone: func(info httptrace.DNSDoneInfo) {
+				dnsDuration = time.Now().Sub(dnsStart)
+			},
+			// TODO: can we just ignore ConnectStart and ConnectDone?
+			GetConn: func(hostPort string) {
+				connStart = time.Now()
+			},
+			GotConn: func(info httptrace.GotConnInfo) {
+				// TODO: info also contains Idle etc.
+				now := time.Now()
+				if info.Reused {
+					connDuration = 0
+				} else {
+					connDuration = now.Sub(connStart)
+				}
+				reqStart = now
+			},
+			// TODO: only tls handshake when new connection is established?
+			TLSHandshakeStart: func() {
+				tlsStart = time.Now()
+			},
+			TLSHandshakeDone: func(state tls.ConnectionState, e error) {
+				tlsDuration = time.Now().Sub(tlsStart)
+			},
+			WroteRequest: func(info httptrace.WroteRequestInfo) {
+				reqDuration = time.Now().Sub(reqStart)
+			},
+			GotFirstResponseByte: func() {
+				resStart = time.Now()
+			},
+		}
+		req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+	}
 	res, err := c.h.Do(req)
+	resDuration = time.Now().Sub(resStart)
 	c.enc.Reset()
 	if err != nil {
 		return errors.Wrap(err, "error send http request")
@@ -86,12 +152,15 @@ func (c *Client) send() error {
 	if err != nil {
 		return errors.Wrap(err, "can't read response body")
 	}
+	c.statusCode = res.StatusCode
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
+		// TODO: might disable this since https://github.com/xephonhq/xephon-b/issues/36 is solved
+		// when the server is overwhelmed, it's pretty likely to have tons of errors ...
 		log.Debugf("%d %s", res.StatusCode, string(b))
 		return errors.New(string(body))
 	}
-
 	c.proto = res.Proto
 	c.bytesSendSuccess += payloadSize
+	log.Infof("res duration %s", resDuration)
 	return nil
 }

--- a/libtsdb/client/influxdbw/client_test.go
+++ b/libtsdb/client/influxdbw/client_test.go
@@ -11,7 +11,7 @@ import (
 
 // TODO: add flag to toggle test base on environ variable ... maybe testutil to gommon, travis etc.
 func TestClient_WriteIntPoint(t *testing.T) {
-	//t.Skip("requires influxdb running")
+	t.Skip("requires influxdb running")
 
 	assert := asst.New(t)
 	c, err := New(*config.NewInfluxdbClientConfig())
@@ -28,7 +28,8 @@ func TestClient_WriteIntPoint(t *testing.T) {
 	})
 	err = c.Flush()
 	trace := c.Trace()
-	t.Logf("%#v", trace)
+	assert.Equal(204, trace.StatusCode)
+	//t.Logf("%v", trace)
 	assert.Nil(err)
 }
 

--- a/libtsdb/client/influxdbw/client_test.go
+++ b/libtsdb/client/influxdbw/client_test.go
@@ -11,10 +11,11 @@ import (
 
 // TODO: add flag to toggle test base on environ variable ... maybe testutil to gommon, travis etc.
 func TestClient_WriteIntPoint(t *testing.T) {
-	t.Skip("requires influxdb running")
+	//t.Skip("requires influxdb running")
 
 	assert := asst.New(t)
 	c, err := New(*config.NewInfluxdbClientConfig())
+	c.EnableHttpTrace()
 	assert.Nil(err)
 	// TODO: util for point generator
 	c.WriteIntPoint(&pb.PointIntTagged{

--- a/libtsdb/client/influxdbw/client_test.go
+++ b/libtsdb/client/influxdbw/client_test.go
@@ -27,6 +27,8 @@ func TestClient_WriteIntPoint(t *testing.T) {
 		},
 	})
 	err = c.Flush()
+	trace := c.Trace()
+	t.Logf("%#v", trace)
 	assert.Nil(err)
 }
 

--- a/libtsdb/trace.go
+++ b/libtsdb/trace.go
@@ -1,0 +1,12 @@
+package libtsdb
+
+import "time"
+
+// TODO: use in generic client
+type HttpTrace struct {
+	DnsDuration  time.Duration
+	ConnDuration time.Duration
+	TlsDuration  time.Duration
+	ReqDuration  time.Duration
+	ResDuration  time.Duration
+}

--- a/libtsdb/trace.go
+++ b/libtsdb/trace.go
@@ -2,11 +2,19 @@ package libtsdb
 
 import "time"
 
-// TODO: use in generic client
+// TODO: it might be more efficient to use unix timestamp
 type HttpTrace struct {
-	DnsDuration  time.Duration
-	ConnDuration time.Duration
-	TlsDuration  time.Duration
-	ReqDuration  time.Duration
-	ResDuration  time.Duration
+	StatusCode int
+	Start      time.Time
+	DNSStart   time.Time
+	DNSDone    time.Time
+	GetConn    time.Time
+	GotConn    time.Time
+	Reused     bool
+	TLSStart   time.Time
+	TLSStop    time.Time
+	ReqStart   time.Time
+	ReqDone    time.Time
+	ResStart   time.Time
+	ResDone    time.Time
 }

--- a/libtsdb/trace.go
+++ b/libtsdb/trace.go
@@ -1,20 +1,18 @@
 package libtsdb
 
-import "time"
-
 // TODO: it might be more efficient to use unix timestamp
 type HttpTrace struct {
 	StatusCode int
-	Start      time.Time
-	DNSStart   time.Time
-	DNSDone    time.Time
-	GetConn    time.Time
-	GotConn    time.Time
+	Start      int64
+	DNSStart   int64
+	DNSDone    int64
+	GetConn    int64
+	GotConn    int64
 	Reused     bool
-	TLSStart   time.Time
-	TLSStop    time.Time
-	ReqStart   time.Time
-	ReqDone    time.Time
-	ResStart   time.Time
-	ResDone    time.Time
+	TLSStart   int64
+	TLSStop    int64
+	ReqStart   int64
+	ReqDone    int64
+	ResStart   int64
+	ResDone    int64
 }


### PR DESCRIPTION
- store all hooked time as int64, not time.Time
- no duration
- also contains status code